### PR TITLE
set meaningful defaults for git in post-create

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -9,6 +9,12 @@ function add_config_if_not_exist {
     fi
 }
 
+function add_git_config_if_not_exist {
+    if ! git config --global --get "$1" > /dev/null; then
+        git config --global "$1" "$2"
+    fi
+}
+
 add_config_if_not_exist "source /opt/ros/humble/setup.bash"
 add_config_if_not_exist "source /opt/ros/lcas/install/setup.bash"
 add_config_if_not_exist "alias rviz_sensors='rviz2 -d /opt/ros/lcas/install/limo_description/share/limo_description/rviz/model_sensors_real.rviz'"
@@ -22,6 +28,15 @@ colcon build --symlink-install --continue-on-error || true
 
 LOCAL_SETUP_FILE=`pwd`/install/setup.bash
 add_config_if_not_exist "if [ -r $LOCAL_SETUP_FILE ]; then source $LOCAL_SETUP_FILE; fi"
+
+
+add_git_config_if_not_exist "core.autocrlf" "input"
+add_git_config_if_not_exist "core.safecrlf" "warn"
+add_git_config_if_not_exist "pull.rebase" "false"
+add_git_config_if_not_exist "user.name" "Anonymous L-CAS DevContainer User"
+add_git_config_if_not_exist "user.email" "noreply@lcas.lincoln.ac.uk"
+add_git_config_if_not_exist "init.defaultBranch" "main"
+
 
 sleep 10
 DISPLAY=:1 xfconf-query -c xfce4-desktop -p $(xfconf-query -c xfce4-desktop -l | grep "workspace0/last-image") -s /usr/share/backgrounds/xfce/lcas.jpg  || true


### PR DESCRIPTION
This pull request introduces a new function to the `.devcontainer/post-create.sh` script for setting global Git configuration options if they do not already exist. Additionally, it includes several calls to this new function to set specific Git configurations.

This is to overcome some user challenges, where git cannot commit because a `user.name` and `user.email` is not set in `~/.gitconfig`. VSCode copies these settings from the host, if they are configured there, or the user has properly set up VSCode already, then it is also correctly set in the container. However, if they don't set it (newbie user), then this sets them to defaults that work.

It also configures the container user's git to handle the CRLF/ LF issue of compatibility between Linux and Windows. This should work, but I don't have Windows to test it.

### Enhancements to `.devcontainer/post-create.sh`:

* Added `add_git_config_if_not_exist` function to check and set global Git configuration options if they are not already set.
* Configured several Git settings using the new `add_git_config_if_not_exist` function:
  - `core.autocrlf` set to `input`
  - `core.safecrlf` set to `warn`
  - `pull.rebase` set to `false`
  - `user.name` set to `Anonymous L-CAS DevContainer User`
  - `user.email` set to `noreply@lcas.lincoln.ac.uk`
  - `init.defaultBranch` set to `main`